### PR TITLE
Handle file descriptor properly

### DIFF
--- a/app/src/main/kotlin/org/fossify/voicerecorder/recorder/MediaRecorderWrapper.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/recorder/MediaRecorderWrapper.kt
@@ -3,9 +3,9 @@ package org.fossify.voicerecorder.recorder
 import android.annotation.SuppressLint
 import android.content.Context
 import android.media.MediaRecorder
+import android.os.ParcelFileDescriptor
 import org.fossify.voicerecorder.extensions.config
 import org.fossify.voicerecorder.helpers.SAMPLE_RATE
-import java.io.FileDescriptor
 
 class MediaRecorderWrapper(val context: Context) : Recorder {
 
@@ -22,8 +22,9 @@ class MediaRecorderWrapper(val context: Context) : Recorder {
         recorder.setOutputFile(path)
     }
 
-    override fun setOutputFile(fileDescriptor: FileDescriptor) {
-        recorder.setOutputFile(fileDescriptor)
+    override fun setOutputFile(parcelFileDescriptor: ParcelFileDescriptor) {
+        val pFD = ParcelFileDescriptor.dup(parcelFileDescriptor.fileDescriptor)
+        recorder.setOutputFile(pFD.fileDescriptor)
     }
 
     override fun prepare() {

--- a/app/src/main/kotlin/org/fossify/voicerecorder/recorder/Mp3Recorder.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/recorder/Mp3Recorder.kt
@@ -64,7 +64,7 @@ class Mp3Recorder(val context: Context) : Recorder {
             return
         }
 
-        val androidLame = LameBuilder()
+        androidLame = LameBuilder()
             .setInSampleRate(SAMPLE_RATE)
             .setOutBitrate(context.config.bitrate / 1000)
             .setOutSampleRate(SAMPLE_RATE)
@@ -83,7 +83,7 @@ class Mp3Recorder(val context: Context) : Recorder {
                 if (!isPaused.get()) {
                     val count = audioRecord.read(rawData, 0, minBufferSize)
                     if (count > 0) {
-                        val encoded = androidLame.encode(rawData, rawData, count, mp3buffer)
+                        val encoded = androidLame!!.encode(rawData, rawData, count, mp3buffer)
                         if (encoded > 0) {
                             try {
                                 updateAmplitude(rawData)

--- a/app/src/main/kotlin/org/fossify/voicerecorder/recorder/Mp3Recorder.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/recorder/Mp3Recorder.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.media.AudioFormat
 import android.media.AudioRecord
+import android.os.ParcelFileDescriptor
 import com.naman14.androidlame.AndroidLame
 import com.naman14.androidlame.LameBuilder
 import org.fossify.commons.extensions.showErrorToast
@@ -11,7 +12,6 @@ import org.fossify.commons.helpers.ensureBackgroundThread
 import org.fossify.voicerecorder.extensions.config
 import org.fossify.voicerecorder.helpers.SAMPLE_RATE
 import java.io.File
-import java.io.FileDescriptor
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
@@ -26,7 +26,7 @@ class Mp3Recorder(val context: Context) : Recorder {
     private var amplitude = AtomicInteger(0)
     private var outputPath: String? = null
     private var androidLame: AndroidLame? = null
-    private var fileDescriptor: FileDescriptor? = null
+    private var fileDescriptor: ParcelFileDescriptor? = null
     private var outputStream: FileOutputStream? = null
     private val minBufferSize = AudioRecord.getMinBufferSize(
         SAMPLE_RATE,
@@ -55,7 +55,7 @@ class Mp3Recorder(val context: Context) : Recorder {
 
         outputStream = try {
             if (fileDescriptor != null) {
-                FileOutputStream(fileDescriptor)
+                FileOutputStream(fileDescriptor!!.fileDescriptor)
             } else {
                 FileOutputStream(File(outputPath!!))
             }
@@ -101,6 +101,7 @@ class Mp3Recorder(val context: Context) : Recorder {
     override fun stop() {
         isPaused.set(true)
         isStopped.set(true)
+        audioRecord.stop()
     }
 
     override fun pause() {
@@ -114,14 +115,15 @@ class Mp3Recorder(val context: Context) : Recorder {
     override fun release() {
         androidLame?.flush(mp3buffer)
         outputStream?.close()
+        audioRecord.release()
     }
 
     override fun getMaxAmplitude(): Int {
         return amplitude.get()
     }
 
-    override fun setOutputFile(fileDescriptor: FileDescriptor) {
-        this.fileDescriptor = fileDescriptor
+    override fun setOutputFile(parcelFileDescriptor: ParcelFileDescriptor) {
+        this.fileDescriptor = ParcelFileDescriptor.dup(parcelFileDescriptor.fileDescriptor)
     }
 
     private fun updateAmplitude(data: ShortArray) {

--- a/app/src/main/kotlin/org/fossify/voicerecorder/recorder/Recorder.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/recorder/Recorder.kt
@@ -1,10 +1,10 @@
 package org.fossify.voicerecorder.recorder
 
-import java.io.FileDescriptor
+import android.os.ParcelFileDescriptor
 
 interface Recorder {
     fun setOutputFile(path: String)
-    fun setOutputFile(fileDescriptor: FileDescriptor)
+    fun setOutputFile(parcelFileDescriptor: ParcelFileDescriptor)
     fun prepare()
     fun start()
     fun stop()

--- a/app/src/main/kotlin/org/fossify/voicerecorder/services/RecorderService.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/services/RecorderService.kt
@@ -113,19 +113,13 @@ class RecorderService : Service() {
             if (isRPlus()) {
                 val fileUri = createDocumentUriUsingFirstParentTreeUri(recordingFile)
                 createSAFFileSdk30(recordingFile)
-
-                val outputFileDescriptor =
-                    contentResolver.openFileDescriptor(fileUri, "w")!!.fileDescriptor
-
-                recorder?.setOutputFile(outputFileDescriptor)
+                contentResolver.openFileDescriptor(fileUri, "w")!!
+                    .use { recorder?.setOutputFile(it) }
             } else if (isPathOnSD(recordingFile)) {
                 var document = getDocumentFile(recordingFile.getParentPath())
                 document = document?.createFile("", recordingFile.getFilenameFromPath())
-
-                val outputFileDescriptor =
-                    contentResolver.openFileDescriptor(document!!.uri, "w")!!.fileDescriptor
-
-                recorder?.setOutputFile(outputFileDescriptor)
+                contentResolver.openFileDescriptor(document!!.uri, "w")!!
+                    .use { recorder?.setOutputFile(it) }
             } else {
                 recorder?.setOutputFile(recordingFile)
             }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR

 - Use `ParcelFileDescriptor.dup()` to create a duplicate FD.
 - Close resource properly using `use`

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #81

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Voice-Recorder/blob/master/CONTRIBUTING.md).
