### PR TITLE
Remove MP3 warning dialog

### DIFF
--- a/app/src/main/kotlin/org/fossify/voicerecorder/fragments/RecorderFragment.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/fragments/RecorderFragment.kt
@@ -9,7 +9,6 @@ import android.os.Looper
 import android.util.AttributeSet
 import org.fossify.commons.activities.BaseSimpleActivity
 import org.fossify.commons.compose.extensions.getActivity
-import org.fossify.commons.dialogs.ConfirmationAdvancedDialog
 import org.fossify.commons.dialogs.PermissionRequiredDialog
 import org.fossify.commons.extensions.applyColorFilter
 import org.fossify.commons.extensions.beVisibleIf
@@ -22,13 +21,11 @@ import org.fossify.commons.extensions.openNotificationSettings
 import org.fossify.commons.extensions.setDebouncedClickListener
 import org.fossify.commons.extensions.toast
 import org.fossify.voicerecorder.R
-import org.fossify.voicerecorder.activities.SettingsActivity
 import org.fossify.voicerecorder.databinding.FragmentRecorderBinding
 import org.fossify.voicerecorder.extensions.config
 import org.fossify.voicerecorder.extensions.ensureStoragePermission
 import org.fossify.voicerecorder.extensions.setKeepScreenAwake
 import org.fossify.voicerecorder.helpers.CANCEL_RECORDING
-import org.fossify.voicerecorder.helpers.EXTENSION_MP3
 import org.fossify.voicerecorder.helpers.GET_RECORDER_INFO
 import org.fossify.voicerecorder.helpers.RECORDING_PAUSED
 import org.fossify.voicerecorder.helpers.RECORDING_RUNNING
@@ -164,32 +161,8 @@ class RecorderFragment(
     }
 
     private fun startRecording() {
-        if (context.config.extension == EXTENSION_MP3) {
-            showExperimentalNotice()
-        } else {
-            Intent(context, RecorderService::class.java).apply {
-                context.startService(this)
-            }
-        }
-    }
-
-    private fun showExperimentalNotice() {
-        val activity = context as? BaseSimpleActivity ?: return
-        ConfirmationAdvancedDialog(
-            activity = activity,
-            messageId = R.string.mp3_experimental_notice,
-            positive = org.fossify.commons.R.string.ok,
-            negative = org.fossify.commons.R.string.go_to_settings
-        ) { recordAnyway ->
-            if (recordAnyway) {
-                Intent(activity, RecorderService::class.java).apply {
-                    activity.startService(this)
-                }
-            } else {
-                Intent(activity, SettingsActivity::class.java).apply {
-                    activity.startActivity(this)
-                }
-            }
+        Intent(context, RecorderService::class.java).apply {
+            context.startService(this)
         }
     }
 

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -30,5 +30,4 @@
     <string name="recording_too_short">Записът е твърде къс!</string>
     <string name="keep_screen_on">Без згасяне на екрана по време на запис</string>
     <string name="confirm_recording_folder">Трябва да потвърдите папката, в която да бъдат запазвани записите. За да продължите изберете Добре.</string>
-    <string name="mp3_experimental_notice">Поддръжката на MP3 е експериментална, използвайте с повишено внимание.</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -35,5 +35,4 @@
     <string name="confirm_recording_folder">Cal confirmar la carpeta on voleu desar les vostres gravacions. Premeu D\'acord per a continuar.</string>
     <string name="move_recordings">Mou els enregistraments</string>
     <string name="move_recordings_to_new_folder_desc">Teniu enregistraments existents. Voleu moure\'ls a la carpeta nova?</string>
-    <string name="mp3_experimental_notice">La implementació de l\'MP3 és experimental, utilitzeu-ho amb precaució.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -35,5 +35,4 @@
     <string name="move_recordings_to_new_folder_desc">Máte existující nahrávky. Chcete je přesunout do nové složky?</string>
     <string name="move_recordings">Přesunout nahrávky</string>
     <string name="confirm_recording_folder">Musíte potvrdit složku, do které chcete nahrávky uložit. Pro pokračování stiskněte tlačítko OK.</string>
-    <string name="mp3_experimental_notice">Podpora MP3 je experimentální, používejte ji prosím s opatrností.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -32,5 +32,4 @@
     <string name="confirm_recording_folder">Du musst den Ordner bestätigen, in dem du deine Aufnahmen speichern möchtest. Bitte auf OK drücken, um fortzufahren.</string>
     <string name="move_recordings_to_new_folder_desc">Du hast bereits vorhandene Aufnahmen. Möchtest du diese in den neuen Ordner verschieben?</string>
     <string name="move_recordings">Aufnahmen verschieben</string>
-    <string name="mp3_experimental_notice">Die MP3-Unterstützung ist experimentell, bitte mit Bedacht verwenden.</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -34,5 +34,4 @@
     <string name="confirm_recording_folder">Sa pead valima kusta, kuhu soovid salvestusi talletada. Jätkamiseks palun vajuta „Sobib“ nuppu.</string>
     <string name="move_recordings_to_new_folder_desc">Sul on olemasolevaid salvestusi. Kas sa soovid neid oma uude kausta tõsta?</string>
     <string name="move_recordings">Salvestuste teisaldamine</string>
-    <string name="mp3_experimental_notice">MP3 tugi on katseline, palun kasuta seda ettevaatlikult.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -34,5 +34,4 @@
     <string name="confirm_recording_folder">A felvételek mentéséhez a mappa megerősítése szükséges. A folytatáshoz nyomja meg az OK gombot.</string>
     <string name="move_recordings_to_new_folder_desc">Meglévő felvételek. Szeretné őket áthelyezni az új mappába?</string>
     <string name="move_recordings">Felvételek áthelyezése</string>
-    <string name="mp3_experimental_notice">Az MP3-támogatás kísérleti stádiumban van, ezért óvatosan használja.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -35,5 +35,4 @@
     <string name="confirm_recording_folder">È necessario confermare la cartella dove vuoi salvare le tue registrazioni. Si prega di premere OK per continuare.</string>
     <string name="recording_too_short">La registrazione era troppo corta per essere registrata!</string>
     <string name="keep_screen_on">Mantieni lo schermo acceso durante la registrazione</string>
-    <string name="mp3_experimental_notice">Il supporto MP3 è sperimentale, si prega di usarlo con cautela.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -34,5 +34,4 @@
     <string name="confirm_recording_folder">Bevestig de map waarin de opnames moeten worden opgeslagen en klik op OK om door te gaan.</string>
     <string name="move_recordings">Opnames verplaatsen</string>
     <string name="move_recordings_to_new_folder_desc">Wil je de bestaande opnames verplaatsen naar de nieuwe map?</string>
-    <string name="mp3_experimental_notice">Pas op: ondersteuning voor MP3 is experimenteel.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -34,5 +34,4 @@
     <string name="confirm_recording_folder">Musisz potwierdzić folder, w którym chcesz zapisywać swoje nagrania. Naciśnij OK, aby kontynuować.</string>
     <string name="move_recordings_to_new_folder_desc">Masz istniejące nagrania. Czy przenieść je do nowego folderu?</string>
     <string name="move_recordings">Przenieś nagrania</string>
-    <string name="mp3_experimental_notice">Obsługa formatu MP3 jest eksperymentalna, dlatego zachowaj ostrożność.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -36,5 +36,4 @@
     <string name="confirm_recording_folder">Необходимо подтвердить папку, в которую вы хотите сохранять свои записи. Нажмите \"OK\" для продолжения.</string>
     <string name="move_recordings">Перемещение записей</string>
     <string name="move_recordings_to_new_folder_desc">У вас есть записи. Переместить их в новую папку?</string>
-    <string name="mp3_experimental_notice">Поддержка MP3 экспериментальная, используйте с осторожностью.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -33,5 +33,4 @@
     <string name="confirm_recording_folder">您必须确认要保存录制的文件夹。请按“确定”继续。</string>
     <string name="move_recordings">移动录音</string>
     <string name="move_recordings_to_new_folder_desc">您有现有的录音。是否要将它们移动到新文件夹？</string>
-    <string name="mp3_experimental_notice">MP3 支持是实验性的，请小心使用。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -33,5 +33,4 @@
     <string name="confirm_recording_folder">您必須確認要儲存錄音的資料夾。請按確定繼續。</string>
     <string name="move_recordings_to_new_folder_desc">您有既有的錄音。您想要將它們移動到新的資料夾嗎？</string>
     <string name="move_recordings">移動錄音</string>
-    <string name="mp3_experimental_notice">MP3 支援為實驗性質，請謹慎使用。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,7 +14,6 @@
     <string name="player">Player</string>
     <!-- Confirmation dialog -->
     <!-- Are you sure you want to delete 5 recordings? -->
-    <string name="mp3_experimental_notice">MP3 support is experimental, please use with caution.</string>
     <string name="delete_recordings_confirmation">Delete %s\?</string>
     <plurals name="delete_recordings">
         <item quantity="one">%d recording</item>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Removed experimental warning dialog
- Removed experimental warning strings

It was originally added for #81 but it does not seem necessary anymore. There is still a `(experimental)` suffix next to `mp3` in settings which will be removed once we are sure about MP3's reliability.

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Voice-Recorder/blob/master/CONTRIBUTING.md).
