### PR TITLE
feat: rename "cancel recording" to "discard recording" (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated translations
+- Renamed "cancel recording" to "discard recording" ([#141])
 
 ## [1.2.0] - 2025-05-20
 
@@ -93,3 +94,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#67]: https://github.com/FossifyOrg/Voice-Recorder/issues/67
 [#81]: https://github.com/FossifyOrg/Voice-Recorder/issues/81
 [#106]: https://github.com/FossifyOrg/Voice-Recorder/issues/106
+[#141]: https://github.com/FossifyOrg/Voice-Recorder/issues/141

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved wording in the recording cancellation dialog ([#141])
 - Updated translations
-- Renamed "cancel recording" to "discard recording" ([#141])
 
 ## [1.2.0] - 2025-05-20
 

--- a/app/src/main/kotlin/org/fossify/voicerecorder/fragments/RecorderFragment.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/fragments/RecorderFragment.kt
@@ -171,8 +171,8 @@ class RecorderFragment(
         val activity = context as? BaseSimpleActivity ?: return
         ConfirmationDialog(
             activity = activity,
-            message = activity.getString(R.string.cancel_recording_confirmation),
-            dialogTitle = activity.getString(R.string.cancel_recording)
+            message = activity.getString(R.string.discard_recording_confirmation),
+            dialogTitle = activity.getString(R.string.discard_recording)
         ) {
             cancelRecording()
         }

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -35,6 +35,6 @@
     <string name="confirm_recording_folder">Cal confirmar la carpeta on voleu desar les vostres gravacions. Premeu D\'acord per a continuar.</string>
     <string name="move_recordings">Mou els enregistraments</string>
     <string name="move_recordings_to_new_folder_desc">Teniu enregistraments existents. Voleu moure\'ls a la carpeta nova?</string>
-    <string name="cancel_recording">Cancel·la l\'enregistrament</string>
-    <string name="cancel_recording_confirmation">Segur que voleu cancel·lar l\'enregistrament actual? Això no es pot desfer.</string>
+    <string name="discard_recording">Cancel·la l\'enregistrament</string>
+    <string name="discard_recording_confirmation">Segur que voleu cancel·lar l\'enregistrament actual? Això no es pot desfer.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -35,6 +35,6 @@
     <string name="move_recordings_to_new_folder_desc">Máte existující nahrávky. Chcete je přesunout do nové složky?</string>
     <string name="move_recordings">Přesunout nahrávky</string>
     <string name="confirm_recording_folder">Musíte potvrdit složku, do které chcete nahrávky uložit. Pro pokračování stiskněte tlačítko OK.</string>
-    <string name="cancel_recording">Zrušit nahrávání</string>
-    <string name="cancel_recording_confirmation">Opravdu chcete zrušit aktuální nahrávání? Tato akce je nevratná.</string>
+    <string name="discard_recording">Zrušit nahrávání</string>
+    <string name="discard_recording_confirmation">Opravdu chcete zrušit aktuální nahrávání? Tato akce je nevratná.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -32,6 +32,6 @@
     <string name="confirm_recording_folder">Du musst den Ordner bestätigen, in dem du deine Aufnahmen speichern möchtest. Bitte auf OK drücken, um fortzufahren.</string>
     <string name="move_recordings_to_new_folder_desc">Du hast bereits vorhandene Aufnahmen. Möchtest du diese in den neuen Ordner verschieben?</string>
     <string name="move_recordings">Aufnahmen verschieben</string>
-    <string name="cancel_recording">Aufnahme abbrechen</string>
-    <string name="cancel_recording_confirmation">Soll die laufende Aufnahme wirklich abgebrochen werden? Dies kann nicht rückgängig gemacht werden.</string>
+    <string name="discard_recording">Aufnahme abbrechen</string>
+    <string name="discard_recording_confirmation">Soll die laufende Aufnahme wirklich abgebrochen werden? Dies kann nicht rückgängig gemacht werden.</string>
 </resources>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -34,6 +34,6 @@
     <string name="recording_too_short">La registro tro mallongis por registri!</string>
     <string name="paused">Paŭzigita</string>
     <string name="player">Legilo</string>
-    <string name="cancel_recording">Nuligi registradon</string>
-    <string name="cancel_recording_confirmation">Ĉu vi certas, ke vi volas nuligi la nunan registradon? Tio ĉi ne malfareblas.</string>
+    <string name="discard_recording">Nuligi registradon</string>
+    <string name="discard_recording_confirmation">Ĉu vi certas, ke vi volas nuligi la nunan registradon? Tio ĉi ne malfareblas.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -33,6 +33,6 @@
     <string name="move_recordings_to_new_folder_desc">Tienes grabaciones existentes. ¿Quieres moverlas a tu nueva carpeta?</string>
     <string name="keep_screen_on">Mantener la pantalla encendida durante la grabación</string>
     <string name="recording_too_short">¡La grabación fue demasiado corta para grabar!</string>
-    <string name="cancel_recording">Cancelar grabación</string>
-    <string name="cancel_recording_confirmation">¿Está seguro de que desea cancelar la grabación actual? Esto no se puede deshacer.</string>
+    <string name="discard_recording">Cancelar grabación</string>
+    <string name="discard_recording_confirmation">¿Está seguro de que desea cancelar la grabación actual? Esto no se puede deshacer.</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -34,6 +34,6 @@
     <string name="confirm_recording_folder">Sa pead valima kausta, kuhu soovid salvestusi talletada. Jätkamiseks palun vajuta „Sobib“ nuppu.</string>
     <string name="move_recordings_to_new_folder_desc">Sul on olemasolevaid salvestusi. Kas sa soovid neid oma uude kausta tõsta?</string>
     <string name="move_recordings">Salvestuste teisaldamine</string>
-    <string name="cancel_recording">Katkesta salvestamine</string>
-    <string name="cancel_recording_confirmation">Kas sa oled kindel, et soovid salvestamise katkestada? Seda tegevust ei saa hiljem tagasi pöörata.</string>
+    <string name="discard_recording">Katkesta salvestamine</string>
+    <string name="discard_recording_confirmation">Kas sa oled kindel, et soovid salvestamise katkestada? Seda tegevust ei saa hiljem tagasi pöörata.</string>
 </resources>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -34,6 +34,6 @@
     <string name="confirm_recording_folder">Zure grabazioak gordetzeko karpeta baieztatu behar duzu. Sakatu Ados jarraitzeko.</string>
     <string name="move_recordings">Mugitu grabazioak</string>
     <string name="move_recordings_to_new_folder_desc">Grabazioak dituzu. Karpeta berrira mugitu nahi dituzu?</string>
-    <string name="cancel_recording">Utzi grabazioa</string>
-    <string name="cancel_recording_confirmation">Ziur al zaude uneko grabazioa utzi nahi duzula? Hau ezin da desegin.</string>
+    <string name="discard_recording">Utzi grabazioa</string>
+    <string name="discard_recording_confirmation">Ziur al zaude uneko grabazioa utzi nahi duzula? Hau ezin da desegin.</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -34,6 +34,6 @@
     <string name="keep_screen_on">Pidä näyttö päällä nauhoituksen aikana</string>
     <string name="confirm_recording_folder">Varmista nauhoitusten tallennuskansio. Paina OK jatkaaksesi.</string>
     <string name="recording_too_short">Nauhoitus oli liian lyhyt!</string>
-    <string name="cancel_recording">Peruuta tallennus</string>
-    <string name="cancel_recording_confirmation">Haluatko varmasti perua nykyisen tallennuksen. Tätä ei voi perua.</string>
+    <string name="discard_recording">Peruuta tallennus</string>
+    <string name="discard_recording_confirmation">Haluatko varmasti perua nykyisen tallennuksen. Tätä ei voi perua.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -35,6 +35,6 @@
     <string name="confirm_recording_folder">Vous devez confirmer le dossier dans lequel vous souhaitez sauvegarder vos enregistrements. Appuyez sur OK pour continuer.</string>
     <string name="keep_screen_on">Garder l\'écran allumé pendant les enregistrements</string>
     <string name="recording_too_short">L\'enregistrement est trop court !</string>
-    <string name="cancel_recording">Annuler l\'enregistrement</string>
-    <string name="cancel_recording_confirmation">Êtes-vous sur de vouloir annuler l\'enregistrement en cours ? Cette action est irrémédiable.</string>
+    <string name="discard_recording">Annuler l\'enregistrement</string>
+    <string name="discard_recording_confirmation">Êtes-vous sur de vouloir annuler l\'enregistrement en cours ? Cette action est irrémédiable.</string>
 </resources>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -35,6 +35,6 @@
     <string name="confirm_recording_folder">Ní mór duit an fillteán a dheimhniú inar mian leat do thaifeadtaí a shábháil. Brúigh OK chun leanúint ar aghaidh.</string>
     <string name="move_recordings_to_new_folder_desc">Tá taifeadtaí agat cheana féin. Ar mhaith leat iad a bhogadh chuig d\'fhillteán nua?</string>
     <string name="move_recordings">Bog taifeadtaí</string>
-    <string name="cancel_recording">Cealaigh an taifeadadh</string>
-    <string name="cancel_recording_confirmation">An bhfuil tú cinnte gur mhaith leat an taifeadadh reatha a chealú? Ní féidir é seo a chealú.</string>
+    <string name="discard_recording">Cealaigh an taifeadadh</string>
+    <string name="discard_recording_confirmation">An bhfuil tú cinnte gur mhaith leat an taifeadadh reatha a chealú? Ní féidir é seo a chealú.</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -30,8 +30,8 @@
     <string name="audio_source_voice_performance">आवाज़ का प्रदर्शन</string>
     <string name="faq_1_title">क्या मैं रिकॉर्डिंग के दौरान अधिसूचना आइकन छुपा सकता हूँ?</string>
     <string name="move_recordings_to_new_folder_desc">आपके पास पहले से रिकॉर्डिंग हैं। क्या आप उन्हें अपने नए फ़ोल्डर में ले जाना चाहते हैं?</string>
-    <string name="cancel_recording">रिकॉर्डिंग रद्द करें</string>
-    <string name="cancel_recording_confirmation">क्या आप वाकई वर्तमान रिकॉर्डिंग रद्द करना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।</string>
+    <string name="discard_recording">रिकॉर्डिंग रद्द करें</string>
+    <string name="discard_recording_confirmation">क्या आप वाकई वर्तमान रिकॉर्डिंग रद्द करना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।</string>
     <string name="keep_screen_on">रिकॉर्डिंग करते समय स्क्रीन चालू रखें</string>
     <string name="confirm_recording_folder">आपको उस फ़ोल्डर की पुष्टि करनी होगी जहां आप अपनी रिकॉर्डिंग सहेजना चाहते हैं। कृपया जारी रखने के लिए OK दबाएँ।</string>
     <string name="recording_too_short">यह रिकार्ड नहीं किया जा सका, यह बहुत छोटा था!</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -34,6 +34,6 @@
     <string name="confirm_recording_folder">A felvételek mentéséhez a mappa megerősítése szükséges. A folytatáshoz nyomja meg az OK gombot.</string>
     <string name="move_recordings_to_new_folder_desc">Meglévő felvételek. Szeretné őket áthelyezni az új mappába?</string>
     <string name="move_recordings">Felvételek áthelyezése</string>
-    <string name="cancel_recording">Felvétel visszavonása</string>
-    <string name="cancel_recording_confirmation">Biztos, hogy visszavonod a felvételt? Visszafordíthatatlan művelet.</string>
+    <string name="discard_recording">Felvétel visszavonása</string>
+    <string name="discard_recording_confirmation">Biztos, hogy visszavonod a felvételt? Visszafordíthatatlan művelet.</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -33,6 +33,6 @@
     <string name="move_recordings">העבר הקלטות</string>
     <string name="move_recordings_to_new_folder_desc">יש לך הקלטות קיימות. האם אתה רוצה להעביר אותם לתיקיה החדשה שלך?</string>
     <string name="confirm_recording_folder">עליך לאשר את התיקיה שבה ברצונך לשמור את ההקלטות שלך. אנא לחץ על אישור כדי להמשיך.</string>
-    <string name="cancel_recording">ביטול הקלטה</string>
-    <string name="cancel_recording_confirmation">האם אתה בטוח שברצונך לבטל את ההקלטה הנוכחית? לא ניתן לבטל פעולה זו.</string>
+    <string name="discard_recording">ביטול הקלטה</string>
+    <string name="discard_recording_confirmation">האם אתה בטוח שברצונך לבטל את ההקלטה הנוכחית? לא ניתן לבטל פעולה זו.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -34,6 +34,6 @@
     <string name="confirm_recording_folder">Bevestig de map waarin de opnames moeten worden opgeslagen en klik op OK om door te gaan.</string>
     <string name="move_recordings">Opnames verplaatsen</string>
     <string name="move_recordings_to_new_folder_desc">Wil je de bestaande opnames verplaatsen naar de nieuwe map?</string>
-    <string name="cancel_recording">Opname annuleren</string>
-    <string name="cancel_recording_confirmation">Weet je zeker dat je de huidige opname wilt annuleren? Dit kan niet worden teruggedraaid.</string>
+    <string name="discard_recording">Opname annuleren</string>
+    <string name="discard_recording_confirmation">Weet je zeker dat je de huidige opname wilt annuleren? Dit kan niet worden teruggedraaid.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -34,6 +34,6 @@
     <string name="confirm_recording_folder">Musisz potwierdzić folder, w którym chcesz zapisywać swoje nagrania. Naciśnij OK, aby kontynuować.</string>
     <string name="move_recordings_to_new_folder_desc">Masz istniejące nagrania. Czy przenieść je do nowego folderu?</string>
     <string name="move_recordings">Przenieś nagrania</string>
-    <string name="cancel_recording">Anuluj nagrywanie</string>
-    <string name="cancel_recording_confirmation">Czy anulować bieżące nagrywanie? Tego nie można cofnąć.</string>
+    <string name="discard_recording">Anuluj nagrywanie</string>
+    <string name="discard_recording_confirmation">Czy anulować bieżące nagrywanie? Tego nie można cofnąć.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -35,6 +35,6 @@
     <string name="confirm_recording_folder">Você deve confirmar a pasta onde deseja salvar suas gravações. Pressione OK para continuar.</string>
     <string name="move_recordings_to_new_folder_desc">Você tem gravações existentes. Quer movê-las para sua nova pasta?</string>
     <string name="recording_too_short">A gravação foi muito curta para gravar!</string>
-    <string name="cancel_recording">Cancelar gravação</string>
-    <string name="cancel_recording_confirmation">Você tem certeza que quer cancelar a gravação atual? Isso não poderá ser desfeito.</string>
+    <string name="discard_recording">Cancelar gravação</string>
+    <string name="discard_recording_confirmation">Você tem certeza que quer cancelar a gravação atual? Isso não poderá ser desfeito.</string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -30,8 +30,8 @@
     <string name="audio_source_voice_communication">Comunicação por voz</string>
     <string name="audio_source_voice_performance">Desempenho de voz</string>
     <string name="faq_1_text">Depende. Actuamente, já não possível ocultar totalmente as notificações em aplicações deste tipo. Tente nas Definições da aplicação, habilitar a alinea correspondente e nas Definições do sistema, desabilitar a apresentação de notificações desta natureza no ecrã de bloqueio.</string>
-    <string name="cancel_recording">Cancelar gravação</string>
-    <string name="cancel_recording_confirmation">Tem certeza que quer cancelar a gravação? Não pode ser desfeito.</string>
+    <string name="discard_recording">Cancelar gravação</string>
+    <string name="discard_recording_confirmation">Tem certeza que quer cancelar a gravação? Não pode ser desfeito.</string>
     <string name="keep_screen_on">Manter o ecrã ligado durante a gravação</string>
     <string name="confirm_recording_folder">Deve confirmar a pasta selecionada onde quer guardar as suas gravações. Clique OK para continuar.</string>
     <string name="move_recordings">Mover gravações</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -36,6 +36,6 @@
     <string name="confirm_recording_folder">Необходимо подтвердить папку, в которую вы хотите сохранять свои записи. Нажмите \"OK\" для продолжения.</string>
     <string name="move_recordings">Перемещение записей</string>
     <string name="move_recordings_to_new_folder_desc">У вас есть записи. Переместить их в новую папку?</string>
-    <string name="cancel_recording">Отменить запись</string>
-    <string name="cancel_recording_confirmation">Отменить текущую запись? Это действие невозможно изменить.</string>
+    <string name="discard_recording">Отменить запись</string>
+    <string name="discard_recording_confirmation">Отменить текущую запись? Это действие невозможно изменить.</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -34,6 +34,6 @@
     <string name="move_recordings_to_new_folder_desc">Du har befintliga inspelningar. Vill du flytta dem till den nya mappen?</string>
     <string name="move_recordings">Flytta inspelningar</string>
     <string name="confirm_recording_folder">Du måste bekräfta mappen där du vill spara dina inspelningar. Tryck på OK för att fortsätta.</string>
-    <string name="cancel_recording">Avbryt inspelning</string>
-    <string name="cancel_recording_confirmation">Är du säker på att du vill avbryta nuvarande inspelning. Det går ej att ångra.</string>
+    <string name="discard_recording">Avbryt inspelning</string>
+    <string name="discard_recording_confirmation">Är du säker på att du vill avbryta nuvarande inspelning. Det går ej att ångra.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -34,6 +34,6 @@
     <string name="move_recordings">Kayıtları taşı</string>
     <string name="confirm_recording_folder">Kayıtlarınızın kaydedileceği klasörü doğrulamanız gerekiyor. Devam etmek için lütfen TAMAM\'a dokunu.</string>
     <string name="move_recordings_to_new_folder_desc">Kayıtlarınız mevcut. Yeni klasörünüze taşımak istiyor musunuz?</string>
-    <string name="cancel_recording">Kaydı iptal et</string>
-    <string name="cancel_recording_confirmation">Şu anda yapılan kaydı iptal etmek istediğinize emin misiniz? Bu işlem geri alınamaz.</string>
+    <string name="discard_recording">Kaydı iptal et</string>
+    <string name="discard_recording_confirmation">Şu anda yapılan kaydı iptal etmek istediğinize emin misiniz? Bu işlem geri alınamaz.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -36,6 +36,6 @@
     <string name="confirm_recording_folder">Ви повинні підтвердити теку, куди хочете зберегти ваші записи. Натисніть «Гаразд», щоби продовжити.</string>
     <string name="move_recordings">Перемістити записи</string>
     <string name="move_recordings_to_new_folder_desc">У вас існують записи. Хочете перемістити їх до нової теки?</string>
-    <string name="cancel_recording">Скасувати записування</string>
-    <string name="cancel_recording_confirmation">Ви впевнені, що хочете скасувати поточний запис? Це не можна скасувати.</string>
+    <string name="discard_recording">Скасувати записування</string>
+    <string name="discard_recording_confirmation">Ви впевнені, що хочете скасувати поточний запис? Це не можна скасувати.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -25,9 +25,9 @@
     <string name="audio_source_voice_performance">Hiệu suất giọng nói</string>
     <string name="faq_1_title">Tôi có thể ẩn biểu tượng thông báo trong khi ghi không\?</string>
     <string name="faq_1_text">Dạ, nó phụ thuộc. Khi bạn sử dụng thiết bị của mình, bạn không thể ẩn hoàn toàn thông báo của các ứng dụng như thế này nữa. Nếu bạn chọn mục cài đặt phù hợp, ứng dụng sẽ cố gắng hết sức để ẩn mục đó. Tuy nhiên, bạn có thể ẩn nó trên màn hình khóa nếu bạn tắt hiển thị các thông báo nhạy cảm trong cài đặt thiết bị của mình.</string>
-    <string name="cancel_recording_confirmation">Bạn có chắc muốn hủy bản ghi âm này? Bản ghi âm sẽ không thể được phục hồi.</string>
+    <string name="discard_recording_confirmation">Bạn có chắc muốn hủy bản ghi âm này? Bản ghi âm sẽ không thể được phục hồi.</string>
     <string name="bitrate">Bitrate</string>
-    <string name="cancel_recording">Hủy ghi âm</string>
+    <string name="discard_recording">Hủy ghi âm</string>
     <string name="keep_screen_on">Giữ màn hình sáng trong khi ghi âm</string>
     <string name="confirm_recording_folder">Bạn cần chọn thư mục để lưu các bản ghi âm. Nhấn OK để chọn.</string>
     <string name="move_recordings">Chuyển bản ghi âm hiện có</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -33,6 +33,6 @@
     <string name="confirm_recording_folder">您必须确认要保存录制的文件夹。请按“确定”继续。</string>
     <string name="move_recordings">移动录音</string>
     <string name="move_recordings_to_new_folder_desc">您有现有的录音。是否要将它们移动到新文件夹？</string>
-    <string name="cancel_recording_confirmation">是否确定要取消当前录制？此操作无法撤销。</string>
-    <string name="cancel_recording">取消录制</string>
+    <string name="discard_recording_confirmation">是否确定要取消当前录制？此操作无法撤销。</string>
+    <string name="discard_recording">取消录制</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -33,6 +33,6 @@
     <string name="confirm_recording_folder">您必須確認要儲存錄音的資料夾。請按確定繼續。</string>
     <string name="move_recordings_to_new_folder_desc">您有既有的錄音。您想要將它們移動到新的資料夾嗎？</string>
     <string name="move_recordings">移動錄音</string>
-    <string name="cancel_recording">取消錄製</string>
-    <string name="cancel_recording_confirmation">您確定要取消目前的錄製嗎？這無法還原。</string>
+    <string name="discard_recording">取消錄製</string>
+    <string name="discard_recording_confirmation">您確定要取消目前的錄製嗎？這無法還原。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,8 +13,8 @@
     <string name="recorder">Recorder</string>
     <string name="player">Player</string>
     <!-- Confirmation dialog -->
-    <string name="cancel_recording">Cancel recording</string>
-    <string name="cancel_recording_confirmation">Are you sure you want to cancel the current recording? This cannot be undone.</string>
+    <string name="discard_recording">Discard recording</string>
+    <string name="discard_recording_confirmation">Are you sure you want to discard the current recording? This cannot be undone.</string>
     <!-- Are you sure you want to delete 5 recordings? -->
     <string name="delete_recordings_confirmation">Delete %s\?</string>
     <plurals name="delete_recordings">


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Renamed "cancel recording" to "discard recording".
- Also renamed string key accordingly.
- I've left translated strings as they are because:
    - Having slightly mistranslated string is better than no translation at all. Translators on Weblate will still be notified about a string change.
    - There may be some languages where direct translation of "cancel" sounds better than direct translation of "discard" (e.g. it's like this in Polish).

#### Before/After Screenshots/Screen Record
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->

![image](https://github.com/user-attachments/assets/32c158da-4611-4214-91ec-908fb41a909b)

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). -->
- Fixes #141 

#### Checklist
- [X] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [X] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [X] I manually tested my changes on device/emulator (if applicable).

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
