### PR TITLE
fix: force app chooser dialog for `Open with` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `Open with` not showing app chooser dialog ([#176])
+
 ## [1.3.1] - 2025-06-17
 
 ### Changed
@@ -118,3 +122,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#141]: https://github.com/FossifyOrg/Voice-Recorder/issues/141
 [#147]: https://github.com/FossifyOrg/Voice-Recorder/issues/147
 [#150]: https://github.com/FossifyOrg/Voice-Recorder/issues/150
+[#176]: https://github.com/FossifyOrg/Voice-Recorder/issues/176

--- a/app/src/main/kotlin/org/fossify/voicerecorder/adapters/RecordingsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/adapters/RecordingsAdapter.kt
@@ -132,7 +132,12 @@ class RecordingsAdapter(
     private fun openRecordingWith() {
         val recording = getItemWithKey(selectedKeys.first()) ?: return
         val path = recording.path
-        activity.openPathIntent(path, false, BuildConfig.APPLICATION_ID, "audio/*")
+        activity.openPathIntent(
+            path = path,
+            forceChooser = true,
+            applicationId = BuildConfig.APPLICATION_ID,
+            forceMimeType = "audio/*"
+        )
     }
 
     private fun shareRecordings() {


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Set `forceChooser = true` to true when calling `openPathIntent()`

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #176 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
