### PR TITLE
Add shortcut to trigger BackgroundRecordActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,7 +60,7 @@
 
         <activity
             android:name="org.fossify.voicerecorder.activities.BackgroundRecordActivity"
-            android:exported="false"
+            android:exported="true"
             android:theme="@style/AppTheme.NoDisplay" />
 
         <activity
@@ -105,6 +105,20 @@
             android:exported="false"
             android:label="@string/customize_colors"
             android:parentActivityName=".activities.SettingsActivity" />
+
+        <activity
+            android:name=".activities.ShortcutActivity"
+            android:label="@string/shortcut_label"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.CREATE_SHORTCUT"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
+
+        <meta-data
+        android:name="android.app.shortcuts"
+        android:resource="@xml/shortcuts" />
 
         <service
             android:name=".services.RecorderService"

--- a/app/src/main/kotlin/org/fossify/voicerecorder/activities/ShortcutActivity.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/activities/ShortcutActivity.kt
@@ -1,0 +1,19 @@
+package org.fossify.voicerecorder.activities
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+
+class ShortcutActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val shortcutIntent = Intent(this, BackgroundRecordActivity::class.java).apply {
+            action = "RECORD_ACTION"
+        }
+
+        setResult(RESULT_OK, shortcutIntent)
+        finish()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="paused">Paused</string>
     <string name="recorder">Recorder</string>
     <string name="player">Player</string>
+    <string name="shortcut_label">Toggle Recording</string>
     <!-- Confirmation dialog -->
     <string name="discard_recording">Discard recording</string>
     <string name="discard_recording_confirmation">Are you sure you want to discard the current recording? This cannot be undone.</string>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,13 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <shortcut
+        android:enabled="true"
+        android:icon="@drawable/ic_microphone_vector"
+        android:shortcutId="shortcut_toggle_recording"
+        android:shortcutShortLabel="@string/shortcut_label">
+        <intent
+            android:action="RECORD_ACTION"
+            android:targetClass="org.fossify.voicerecorder.BackgroundRecordActivity"
+            android:targetPackage="org.fossify.voicerecorder" />
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Added a shortcut to toggle recording that can be called by applications such as KeyMapper

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #26
- Closes #98

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
