### PR TITLE
fix: increase `maxLines` for recording item text view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed clipped filenames in the recordings list ([#96])
 
 ## [1.3.3] - 2025-07-29
 ### Changed
@@ -93,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#57]: https://github.com/FossifyOrg/Voice-Recorder/issues/57
 [#67]: https://github.com/FossifyOrg/Voice-Recorder/issues/67
 [#81]: https://github.com/FossifyOrg/Voice-Recorder/issues/81
+[#96]: https://github.com/FossifyOrg/Voice-Recorder/issues/96
 [#106]: https://github.com/FossifyOrg/Voice-Recorder/issues/106
 [#141]: https://github.com/FossifyOrg/Voice-Recorder/issues/141
 [#147]: https://github.com/FossifyOrg/Voice-Recorder/issues/147

--- a/app/src/main/res/layout/item_recording.xml
+++ b/app/src/main/res/layout/item_recording.xml
@@ -21,7 +21,7 @@
             android:layout_height="wrap_content"
             android:ellipsize="end"
             android:includeFontPadding="false"
-            android:maxLines="1"
+            android:maxLines="2"
             android:paddingEnd="@dimen/activity_margin"
             android:textSize="@dimen/big_text_size"
             app:layout_constraintBottom_toTopOf="@+id/recording_date"


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Increased `maxLines` to 2 for recording item text view. This helps avoid clipping for longer filenames.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Voice-Recorder/issues/96

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
