### PR TITLE
chore: remove audio source preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Removed `Audio source` preference ([#16])
+
 ### Fixed
 - Fixed clipped filenames in the recordings list ([#96])
 
@@ -88,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[#16]: https://github.com/FossifyOrg/Voice-Recorder/issues/16
 [#22]: https://github.com/FossifyOrg/Voice-Recorder/issues/22
 [#33]: https://github.com/FossifyOrg/Voice-Recorder/issues/33
 [#40]: https://github.com/FossifyOrg/Voice-Recorder/issues/40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
-- Removed `Audio source` preference ([#16])
 
 ### Fixed
 - Fixed clipped filenames in the recordings list ([#96])
+
+### Removed
+- Removed unnecessary `Audio source` preference ([#16])
 
 ## [1.3.3] - 2025-07-29
 ### Changed

--- a/app/src/main/kotlin/org/fossify/voicerecorder/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/activities/SettingsActivity.kt
@@ -1,7 +1,6 @@
 package org.fossify.voicerecorder.activities
 
 import android.content.Intent
-import android.media.MediaRecorder
 import android.os.Bundle
 import org.fossify.commons.dialogs.ChangeDateTimeFormatDialog
 import org.fossify.commons.dialogs.ConfirmationDialog
@@ -81,7 +80,6 @@ class SettingsActivity : SimpleActivity() {
         setupExtension()
         setupBitrate()
         setupSamplingRate()
-        setupAudioSource()
         setupRecordAfterLaunch()
         setupKeepScreenOn()
         setupUseRecycleBin()
@@ -338,44 +336,5 @@ class SettingsActivity : SimpleActivity() {
                 }
             }
         }
-    }
-
-    private fun setupAudioSource() {
-        binding.settingsAudioSource.text = config.getAudioSourceText(config.audioSource)
-        binding.settingsAudioSourceHolder.setOnClickListener {
-            val items = getAudioSources()
-                .map {
-                    RadioItem(
-                        id = it,
-                        title = config.getAudioSourceText(it)
-                    )
-                } as ArrayList
-
-            RadioGroupDialog(
-                activity = this@SettingsActivity,
-                items = items,
-                checkedItemId = config.audioSource
-            ) {
-                config.audioSource = it as Int
-                binding.settingsAudioSource.text = config.getAudioSourceText(config.audioSource)
-            }
-        }
-    }
-
-    private fun getAudioSources(): ArrayList<Int> {
-        val availableSources = arrayListOf(
-            MediaRecorder.AudioSource.CAMCORDER,
-            MediaRecorder.AudioSource.DEFAULT,
-            MediaRecorder.AudioSource.MIC,
-            MediaRecorder.AudioSource.VOICE_RECOGNITION,
-            MediaRecorder.AudioSource.VOICE_COMMUNICATION,
-            MediaRecorder.AudioSource.UNPROCESSED
-        )
-
-        if (isQPlus()) {
-            availableSources.add(MediaRecorder.AudioSource.VOICE_PERFORMANCE)
-        }
-
-        return availableSources
     }
 }

--- a/app/src/main/kotlin/org/fossify/voicerecorder/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/helpers/Config.kt
@@ -21,22 +21,6 @@ class Config(context: Context) : BaseConfig(context) {
         get() = prefs.getInt(EXTENSION, EXTENSION_M4A)
         set(extension) = prefs.edit().putInt(EXTENSION, extension).apply()
 
-    var audioSource: Int
-        get() = prefs.getInt(AUDIO_SOURCE, MediaRecorder.AudioSource.CAMCORDER)
-        set(audioSource) = prefs.edit().putInt(AUDIO_SOURCE, audioSource).apply()
-
-    fun getAudioSourceText(audioSource: Int) = context.getString(
-        when (audioSource) {
-            MediaRecorder.AudioSource.DEFAULT -> R.string.audio_source_default
-            MediaRecorder.AudioSource.MIC -> R.string.audio_source_microphone
-            MediaRecorder.AudioSource.VOICE_RECOGNITION -> R.string.audio_source_voice_recognition
-            MediaRecorder.AudioSource.VOICE_COMMUNICATION -> R.string.audio_source_voice_communication
-            MediaRecorder.AudioSource.UNPROCESSED -> R.string.audio_source_unprocessed
-            MediaRecorder.AudioSource.VOICE_PERFORMANCE -> R.string.audio_source_voice_performance
-            else -> R.string.audio_source_camcorder
-        }
-    )
-
     var bitrate: Int
         get() = prefs.getInt(BITRATE, DEFAULT_BITRATE)
         set(bitrate) = prefs.edit().putInt(BITRATE, bitrate).apply()

--- a/app/src/main/kotlin/org/fossify/voicerecorder/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/helpers/Constants.kt
@@ -2,6 +2,8 @@
 
 package org.fossify.voicerecorder.helpers
 
+import android.media.MediaRecorder
+
 const val REPOSITORY_NAME = "Voice-Recorder"
 
 const val RECORDER_RUNNING_NOTIF_ID = 10000
@@ -84,6 +86,8 @@ val SAMPLING_RATE_BITRATE_LIMITS = mapOf(
     EXTENSION_OGG to SAMPLING_RATE_BITRATE_LIMITS_OPUS
 )
 
+const val RECORDING_AUDIO_SOURCE = MediaRecorder.AudioSource.CAMCORDER
+
 const val RECORDING_RUNNING = 0
 const val RECORDING_STOPPED = 1
 const val RECORDING_PAUSED = 2
@@ -94,7 +98,6 @@ const val TOGGLE_WIDGET_UI = "toggle_widget_ui"
 // shared preferences
 const val SAVE_RECORDINGS = "save_recordings"
 const val EXTENSION = "extension"
-const val AUDIO_SOURCE = "audio_source"
 const val BITRATE = "bitrate"
 const val SAMPLING_RATE = "sampling_rate"
 const val RECORD_AFTER_LAUNCH = "record_after_launch"

--- a/app/src/main/kotlin/org/fossify/voicerecorder/recorder/MediaRecorderWrapper.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/recorder/MediaRecorderWrapper.kt
@@ -5,12 +5,13 @@ import android.content.Context
 import android.media.MediaRecorder
 import android.os.ParcelFileDescriptor
 import org.fossify.voicerecorder.extensions.config
+import org.fossify.voicerecorder.helpers.RECORDING_AUDIO_SOURCE
 
 class MediaRecorderWrapper(val context: Context) : Recorder {
 
     @Suppress("DEPRECATION")
     private var recorder = MediaRecorder().apply {
-        setAudioSource(context.config.audioSource)
+        setAudioSource(RECORDING_AUDIO_SOURCE)
         setOutputFormat(context.config.getOutputFormat())
         setAudioEncoder(context.config.getAudioEncoder())
         setAudioEncodingBitRate(context.config.bitrate)

--- a/app/src/main/kotlin/org/fossify/voicerecorder/recorder/Mp3Recorder.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/recorder/Mp3Recorder.kt
@@ -10,6 +10,7 @@ import com.naman14.androidlame.LameBuilder
 import org.fossify.commons.extensions.showErrorToast
 import org.fossify.commons.helpers.ensureBackgroundThread
 import org.fossify.voicerecorder.extensions.config
+import org.fossify.voicerecorder.helpers.RECORDING_AUDIO_SOURCE
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
@@ -35,7 +36,7 @@ class Mp3Recorder(val context: Context) : Recorder {
 
     @SuppressLint("MissingPermission")
     private val audioRecord = AudioRecord(
-        context.config.audioSource,
+        RECORDING_AUDIO_SOURCE,
         context.config.samplingRate,
         AudioFormat.CHANNEL_IN_MONO,
         AudioFormat.ENCODING_PCM_16BIT,

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -281,28 +281,6 @@
 
             </RelativeLayout>
 
-            <RelativeLayout
-                android:id="@+id/settings_audio_source_holder"
-                style="@style/SettingsHolderTextViewStyle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <org.fossify.commons.views.MyTextView
-                    android:id="@+id/settings_audio_source_label"
-                    style="@style/SettingsTextLabelStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/audio_source" />
-
-                <org.fossify.commons.views.MyTextView
-                    android:id="@+id/settings_audio_source"
-                    style="@style/SettingsTextValueStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_below="@+id/settings_audio_source_label"
-                    tools:text="Camera" />
-            </RelativeLayout>
-
             <include
                 android:id="@+id/settings_recording_divider"
                 layout="@layout/divider" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,14 +28,6 @@
     <string name="record_after_launch">Start recording automatically after launching the app</string>
     <string name="keep_screen_on">Keep the screen on during recording</string>
     <string name="sample_rate">Sample rate</string>
-    <!-- Settings Audio source selection -->
-    <string name="audio_source_camcorder">Camera</string>
-    <string name="audio_source_default">Android default</string>
-    <string name="audio_source_unprocessed">Unprocessed</string>
-    <string name="audio_source_microphone">Microphone</string>
-    <string name="audio_source_voice_recognition">Voice recognition</string>
-    <string name="audio_source_voice_communication">Voice communication</string>
-    <string name="audio_source_voice_performance">Voice performance</string>
     <!-- FAQ -->
     <string name="faq_1_title">Can I hide the notification icon during recording?</string>
     <string name="faq_1_text">Well, it depends. While you use your device it is no longer possible to fully hide the notifications of apps like this.


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Removed the **Audio source** preference. While it may help solve some device-specific issues, it's not user friendly at all. Something will be done about it if users report issues related to this. The `Audio source` string was not removed for future usage as described in https://github.com/FossifyOrg/Voice-Recorder/issues/16#issuecomment-3170484128.
- As before, the hardcoded audio source is `MediaRecorder.AudioSource.CAMCORDER`

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Voice-Recorder/issues/16

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ ] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
