### PR TITLE
fix: pause playback when audio becomes noisy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Playback is now paused when external audio devices are disconnected ([#247])
 
 ## [1.5.0] - 2025-10-29
 ### Changed
@@ -130,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#150]: https://github.com/FossifyOrg/Voice-Recorder/issues/150
 [#176]: https://github.com/FossifyOrg/Voice-Recorder/issues/176
 [#185]: https://github.com/FossifyOrg/Voice-Recorder/issues/185
+[#247]: https://github.com/FossifyOrg/Voice-Recorder/issues/247
 
 [Unreleased]: https://github.com/FossifyOrg/Voice-Recorder/compare/1.5.0...HEAD
 [1.5.0]: https://github.com/FossifyOrg/Voice-Recorder/compare/1.4.0...1.5.0

--- a/app/src/main/kotlin/org/fossify/voicerecorder/receivers/BecomingNoisyReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/receivers/BecomingNoisyReceiver.kt
@@ -1,0 +1,16 @@
+package org.fossify.voicerecorder.receivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.media.AudioManager
+
+class BecomingNoisyReceiver(
+    private val onBecomingNoisy: () -> Unit
+) : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == AudioManager.ACTION_AUDIO_BECOMING_NOISY) {
+            onBecomingNoisy()
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Added a `BecomingNoisyReceiver` to listen for `AudioManager.ACTION_AUDIO_BECOMING_NOISY` and pause playback.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Disconnecting earbuds while recording is playing. I have not tested with wired earphones.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Voice-Recorder/issues/247

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
