### PR TITLE
fix: allow lowercase recording names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed automatic word capitalization when renaming recordings ([#397])
 
 ## [1.7.1] - 2026-02-14
 ### Changed
@@ -164,6 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#247]: https://github.com/FossifyOrg/Voice-Recorder/issues/247
 [#256]: https://github.com/FossifyOrg/Voice-Recorder/issues/256
 [#273]: https://github.com/FossifyOrg/Voice-Recorder/issues/273
+[#397]: https://github.com/FossifyOrg/Voice-Recorder/issues/397
 
 [Unreleased]: https://github.com/FossifyOrg/Voice-Recorder/compare/1.7.1...HEAD
 [1.7.1]: https://github.com/FossifyOrg/Voice-Recorder/compare/1.7.0...1.7.1

--- a/app/src/main/res/layout/dialog_rename_recording.xml
+++ b/app/src/main/res/layout/dialog_rename_recording.xml
@@ -20,7 +20,7 @@
             android:id="@+id/rename_recording_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="textCapWords"
+            android:inputType="text"
             android:singleLine="true"
             android:textCursorDrawable="@null"
             android:textSize="@dimen/bigger_text_size" />


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Replaced title-case input with plain text input in the rename dialog
- Allows recording names to keep lowercase words as entered

#### Tests performed
- `./gradlew :app:testFossDebugUnitTest detekt lint :app:assembleFossDebug --no-daemon`
- POCO X2 running Android 15

#### Closes the following issue(s)
- Closes #397

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.