### PR TITLE
fix: prevent page swipes while seeking

### DIFF
--- a/app/src/main/kotlin/org/fossify/voicerecorder/views/PlayerSeekBar.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/views/PlayerSeekBar.kt
@@ -1,0 +1,44 @@
+package org.fossify.voicerecorder.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import org.fossify.commons.views.MySeekBar
+
+class PlayerSeekBar : MySeekBar {
+    private var isParentInterceptionDisallowed = false
+
+    constructor(context: Context) : super(context)
+
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+
+    constructor(context: Context, attrs: AttributeSet, defStyle: Int) : super(context, attrs, defStyle)
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        val action = event.actionMasked
+        if (action == MotionEvent.ACTION_DOWN) {
+            setParentInterceptionDisallowed(true)
+        }
+
+        val handled = super.onTouchEvent(event)
+        if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL || !handled) {
+            setParentInterceptionDisallowed(false)
+        }
+
+        return handled
+    }
+
+    override fun performClick() = super.performClick()
+
+    override fun onDetachedFromWindow() {
+        setParentInterceptionDisallowed(false)
+        super.onDetachedFromWindow()
+    }
+
+    private fun setParentInterceptionDisallowed(disallowed: Boolean) {
+        if (isParentInterceptionDisallowed != disallowed) {
+            parent?.requestDisallowInterceptTouchEvent(disallowed)
+            isParentInterceptionDisallowed = disallowed
+        }
+    }
+}

--- a/app/src/main/kotlin/org/fossify/voicerecorder/views/PlayerSeekBar.kt
+++ b/app/src/main/kotlin/org/fossify/voicerecorder/views/PlayerSeekBar.kt
@@ -21,6 +21,10 @@ class PlayerSeekBar : MySeekBar {
         }
 
         val handled = super.onTouchEvent(event)
+        if (action == MotionEvent.ACTION_UP && handled) {
+            performClick()
+        }
+
         if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL || !handled) {
             setParentInterceptionDisallowed(false)
         }

--- a/app/src/main/res/layout/fragment_player.xml
+++ b/app/src/main/res/layout/fragment_player.xml
@@ -90,7 +90,7 @@
             android:paddingEnd="@dimen/medium_margin"
             android:text="00:00" />
 
-        <org.fossify.commons.views.MySeekBar
+        <org.fossify.voicerecorder.views.PlayerSeekBar
             android:id="@+id/player_progressbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Prevent the page view from intercepting seekbar drag gestures
- Restore normal page swiping after the gesture ends, is canceled, or the seekbar is detached
- Keep the existing seekbar styling and accessibility click behavior

#### Tests performed
- `./gradlew detekt`

#### Closes the following issue(s)
- Closes #82

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ ] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.
